### PR TITLE
Update requirements versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
+django==1.11.3
 django-model-utils==3.0.0
-# Use latest code in Django 1.11 branch until 1.11.3 is released
-https://github.com/django/django/archive/stable/1.11.x.zip
 Pillow==4.1.1
 
 # Only needed for running tests.

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=[
-        'django-model-utils == 3.0.0',
-        'Django >= 1.11',
-        'Pillow==4.1.1'
+        'django-model-utils>=3.0.0',
+        'Django>=1.11',
+        'Pillow>=4.0.0'
     ],
     test_suite='runtests.runtests'
 )


### PR DESCRIPTION
`install_requires` versions are loosened and Django is pinned in requirements.txt now that 1.11.3 is out.