### PR TITLE
Make result template overridable.

### DIFF
--- a/quiz/views.py
+++ b/quiz/views.py
@@ -136,6 +136,7 @@ class QuizTake(FormView):
     form_class = QuestionForm
     template_name = 'question.html'
     result_template_name = 'result.html'
+    single_complete_template_name = 'single_complete.html'
 
     def dispatch(self, request, *args, **kwargs):
         self.quiz = get_object_or_404(Quiz, url=self.kwargs['quiz_name'])
@@ -151,7 +152,7 @@ class QuizTake(FormView):
             self.sitting = self.anon_load_sitting()
 
         if self.sitting is False:
-            return render(request, 'single_complete.html')
+            return render(request, self.single_complete_template_name)
 
         return super(QuizTake, self).dispatch(request, *args, **kwargs)
 

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -135,6 +135,7 @@ class QuizMarkingDetail(QuizMarkerMixin, DetailView):
 class QuizTake(FormView):
     form_class = QuestionForm
     template_name = 'question.html'
+    result_template_name = 'result.html'
 
     def dispatch(self, request, *args, **kwargs):
         self.quiz = get_object_or_404(Quiz, url=self.kwargs['quiz_name'])
@@ -244,7 +245,7 @@ class QuizTake(FormView):
         if self.quiz.exam_paper is False:
             self.sitting.delete()
 
-        return render(self.request, 'result.html', results)
+        return render(self.request, self.result_template_name, results)
 
     def anon_load_sitting(self):
         if self.quiz.single_attempt is True:


### PR DESCRIPTION
This is so the template can be specified without having to redefine
the method.