### PR TITLE
sc-12683 Replace ugettext_lazy by gettext_lazy compatible for django4

### DIFF
--- a/essay/models.py
+++ b/essay/models.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from quiz.models import Question
 from six import python_2_unicode_compatible
 

--- a/multichoice/models.py
+++ b/multichoice/models.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from quiz.models import Question
 from six import python_2_unicode_compatible
 

--- a/quiz/admin.py
+++ b/quiz/admin.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.contrib import admin
 from django.contrib.admin.widgets import FilteredSelectMultiple
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import Quiz, Category, SubCategory, Progress, Question
 from multichoice.models import MCQuestion, Answer

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError, ImproperlyConfigured
 from django.core.validators import (
     MaxValueValidator, validate_comma_separated_integer_list,
 )
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.timezone import now
 from django.conf import settings
 

--- a/quiz/tests.py
+++ b/quiz/tests.py
@@ -13,7 +13,7 @@ from django.http import HttpRequest
 from django.template import Template, Context
 from django.test import TestCase
 from django.utils.six import StringIO
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import Category, Quiz, Progress, Sitting, SubCategory
 from .views import (anon_session_score, QuizListView, CategoriesListView,

--- a/true_false/models.py
+++ b/true_false/models.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from six import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.db import models
 from quiz.models import Question
 


### PR DESCRIPTION
`ugettext_lazy` was replaced by `gettext_lazy` in Django 4.2